### PR TITLE
Release 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The following is an example of a JSON object lambda-sailthru expects. You will a
 `postParams`: JS object that provides required Sailthru API parameters. See [Sailthru API](https://getstarted.sailthru.com/new-for-developers-overview/api/api-overview/) documentation for examples.
 
 ## Deployment
-If you installed node-lambda there are two options availiable
+If you installed node-lambda there are two options available
 
 1. `node-lambda package`
 

--- a/event.json.example
+++ b/event.json.example
@@ -1,11 +1,14 @@
 {
-  "apiType": "",
-  "apiKey": "",
-  "postParams": {
-    "id": "",
-    "key": "",
-    "vars": {
-      "test": "true"
+  "body": {
+    "apiType": "",
+    "apiKey": "",
+    "sailthruEnv": "",
+    "postParams": {
+      "id": "",
+      "key": "",
+      "vars": {
+        "test": "true"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lambda-sailthru",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "AWS Lambda function to dispatch POST API events to SailThru",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
SailThru connection should be built using the `sailthruEnv` parameter. If this parameter is provided the SailThru connection can connect to different applications based upon the `SAILTHRU_DEV_API_KEY` and `SAILTHRU_DEV_API_SECRET` keys provided in the enviroment configuration.
